### PR TITLE
0.0.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@
 [metadata]
 license_files = LICENSE
 name = xrp-price-aggregate
-version = 0.0.4
+version = 0.0.5
 author = Joseph Chiocchi
 author_email = joe@yolk.cc
 description = A utility library that wraps grabbing the current spot price of $XRP from various exchanges.

--- a/src/xrp_price_aggregate/__main__.py
+++ b/src/xrp_price_aggregate/__main__.py
@@ -1,4 +1,4 @@
 from . import as_json
 
 
-print(as_json())
+print(as_json(count=3, delay=0.1, fast=True))

--- a/src/xrp_price_aggregate/__main__.py
+++ b/src/xrp_price_aggregate/__main__.py
@@ -1,4 +1,4 @@
 from . import as_json
 
 
-print(as_json(count=3, delay=0.1, fast=True))
+print(as_json(count=2, delay=0.25, fast=True))

--- a/src/xrp_price_aggregate/__main__.py
+++ b/src/xrp_price_aggregate/__main__.py
@@ -1,4 +1,9 @@
+import sys
+
 from . import as_json
 
 
-print(as_json(count=2, delay=0.25, fast=True))
+# call with the fast parameter by default, unless provided with -exhaustive
+fast = not sys.argv[-1].endswith(("--exhaustive", "-E", "-L", "--long", "--ccxt"))
+
+print(as_json(count=2, delay=0.25, fast=fast))

--- a/src/xrp_price_aggregate/__main__.py
+++ b/src/xrp_price_aggregate/__main__.py
@@ -3,7 +3,8 @@ import sys
 from . import as_json
 
 
-# call with the fast parameter by default, unless provided with -exhaustive
+# call with the fast parameter by default...
+# ...unless provided with a short or long option
 fast = not sys.argv[-1].endswith(("--exhaustive", "-E", "-L", "--long", "--ccxt"))
 
 print(as_json(count=2, delay=0.25, fast=fast))

--- a/src/xrp_price_aggregate/aggregate_filter.py
+++ b/src/xrp_price_aggregate/aggregate_filter.py
@@ -114,6 +114,7 @@ async def _aggregate_multiple(count: int, delay: int) -> Dict[str, Any]:
 
     try:
         all_results: List[Tuple[str, Decimal]] = [
+            # the gathered results are nested per client, we flatten it
             result for results in await asyncio.gather(*tasks) for result in results
         ]
 

--- a/src/xrp_price_aggregate/providers/__init__.py
+++ b/src/xrp_price_aggregate/providers/__init__.py
@@ -1,5 +1,5 @@
 from .base import ExchangeClient
-from .gen_default import generate_default
+from .gen_default import generate_default, generate_fast
 
 
-__all__ = ["ExchangeClient", "generate_default"]
+__all__ = ["ExchangeClient", "generate_default", "generate_fast"]

--- a/src/xrp_price_aggregate/providers/binance.py
+++ b/src/xrp_price_aggregate/providers/binance.py
@@ -41,4 +41,3 @@ class Binance(FakeCCXT):
             # out, but skew the raw, unfiltered results
             "last": json_resp.get("price", "0")
         }
-

--- a/src/xrp_price_aggregate/providers/binance.py
+++ b/src/xrp_price_aggregate/providers/binance.py
@@ -8,6 +8,7 @@ class Binance(FakeCCXT):
     Binance has a public endpoint for fetching a price of a symbol.
     """
 
+    fast = True
     fetch_ticker_url = "https://api.binance.com/api/v3/ticker/price"
 
     @property

--- a/src/xrp_price_aggregate/providers/binance.py
+++ b/src/xrp_price_aggregate/providers/binance.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict
+
+from .base import FakeCCXT
+
+
+class Binance(FakeCCXT):
+    """
+    Binance has a public endpoint for fetching a price of a symbol.
+    """
+
+    fetch_ticker_url = "https://api.binance.com/api/v3/ticker/price"
+
+    @property
+    def id(self) -> str:
+        return "binance"
+
+    @classmethod
+    def price_to_precision(cls, _, value: str) -> str:
+        """We have no intelligence for precision in this client"""
+        return value
+
+    async def fetch_ticker(self, symbol: str) -> Dict[str, str]:
+        """Grab the response from our endpoint
+
+        Grab the response from our endpoint, return a dict with the expected
+        key of "last"
+
+
+        Args:
+            symbol (str): The symbol to request from the endpoint, like XRPUSDT
+
+        Returns:
+            Dict of [str, str]: The results in a shape that includes our
+                                expected "last" key
+        """
+        resp = await self.client.get(self.fetch_ticker_url, params={"symbol": symbol})
+        json_resp = resp.json()
+        return {
+            # default to 0 seems intelligent since it'll definitely be filtered
+            # out, but skew the raw, unfiltered results
+            "last": json_resp.get("price", "0")
+        }
+

--- a/src/xrp_price_aggregate/providers/bitrue.py
+++ b/src/xrp_price_aggregate/providers/bitrue.py
@@ -8,6 +8,7 @@ class Bitrue(FakeCCXT):
     Bitrue has a public endpoint for fetching a price of a symbol.
     """
 
+    fast = True
     fetch_ticker_url = "https://www.bitrue.com/api/v1/ticker/price"
 
     @property

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -15,6 +15,8 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
     bitstamp = ccxt.bitstamp()
     cex = ccxt.cex()
     ftx = ccxt.ftx()
+    # example where we could set a ccxt client as 'fast' directly, not really
+    # intelligent, just empirical
     # setattr(ftx, "fast", True)
     hitbtc = ccxt.hitbtc()
     kraken = ccxt.kraken()

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -3,10 +3,13 @@ from typing import List, Set, Tuple
 import ccxt.async_support as ccxt  # type: ignore
 
 from .base import ExchangeClient
+from .binance import Binance
 from .bitrue import Bitrue
+from .kraken import Kraken
 
 
-async def generate_default() -> Tuple[
+# async def generate_default() -> Tuple[
+def generate_default() -> Tuple[
     Set[ExchangeClient], List[Tuple[ExchangeClient, str]]
 ]:
     # get these popular, high volume exchanges from ccxt directly
@@ -16,9 +19,11 @@ async def generate_default() -> Tuple[
     cex = ccxt.cex()
     ftx = ccxt.ftx()
     hitbtc = ccxt.hitbtc()
-    kraken = ccxt.kraken()
+    # kraken = ccxt.kraken()
     # use our ccxt-like clients
     bitrue = Bitrue()
+    binance2 = Binance()
+    kraken2 = Kraken()
     # combine them all into a set for reference and iterating later
     exchanges = {
         binance,
@@ -27,8 +32,10 @@ async def generate_default() -> Tuple[
         cex,
         ftx,
         hitbtc,
-        kraken,
+        # kraken,
         bitrue,
+        binance2,
+        kraken2,
     }
 
     # this could be more intelligently created, but this literal mapping is
@@ -42,7 +49,9 @@ async def generate_default() -> Tuple[
         (ftx, "XRP/USD"),
         (ftx, "XRP/USDT"),
         (hitbtc, "XRP/USDT"),
-        (kraken, "XRP/USD"),
+        # (kraken, "XRP/USD"),
         (bitrue, "XRPUSDT"),
+        (binance2, "XRPUSDT"),
+        (kraken2, "XRPUSD"),
     ]
     return exchanges, exchange_with_tickers

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -19,7 +19,7 @@ def generate_default() -> Tuple[
     cex = ccxt.cex()
     ftx = ccxt.ftx()
     hitbtc = ccxt.hitbtc()
-    # kraken = ccxt.kraken()
+    kraken = ccxt.kraken()
     # use our ccxt-like clients
     bitrue = Bitrue()
     binance2 = Binance()

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -8,16 +8,14 @@ from .bitrue import Bitrue
 from .kraken import Kraken
 
 
-# async def generate_default() -> Tuple[
-def generate_default() -> Tuple[
-    Set[ExchangeClient], List[Tuple[ExchangeClient, str]]
-]:
+def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, str]]]:
     # get these popular, high volume exchanges from ccxt directly
     binance = ccxt.binance()
     bitfinex = ccxt.bitfinex()
     bitstamp = ccxt.bitstamp()
     cex = ccxt.cex()
     ftx = ccxt.ftx()
+    # setattr(ftx, "fast", True)
     hitbtc = ccxt.hitbtc()
     kraken = ccxt.kraken()
     # use our ccxt-like clients
@@ -32,7 +30,7 @@ def generate_default() -> Tuple[
         cex,
         ftx,
         hitbtc,
-        # kraken,
+        kraken,
         bitrue,
         binance2,
         kraken2,
@@ -49,9 +47,29 @@ def generate_default() -> Tuple[
         (ftx, "XRP/USD"),
         (ftx, "XRP/USDT"),
         (hitbtc, "XRP/USDT"),
-        # (kraken, "XRP/USD"),
+        (kraken, "XRP/USD"),
         (bitrue, "XRPUSDT"),
         (binance2, "XRPUSDT"),
         (kraken2, "XRPUSD"),
     ]
     return exchanges, exchange_with_tickers
+
+
+def generate_fast() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, str]]]:
+    """
+    This will return the exchanges filtered from the default set if they have
+    a `fast` attribute.
+    """
+    exchanges, exchange_with_tickers = generate_default()
+    # set up our filter predicates
+    filter_pred_fast_exchange_client = lambda exchange_client: hasattr(
+        exchange_client, "fast"
+    )
+    filter_pred_fast_exchange_with_ticker = (
+        lambda exchange_ticker: filter_pred_fast_exchange_client(exchange_ticker[0])
+    )
+    filtered_exchanges = set(filter(filter_pred_fast_exchange_client, exchanges))
+    filtered_exchange_with_tickers = list(
+        filter(filter_pred_fast_exchange_with_ticker, exchange_with_tickers)
+    )
+    return filtered_exchanges, filtered_exchange_with_tickers

--- a/src/xrp_price_aggregate/providers/kraken.py
+++ b/src/xrp_price_aggregate/providers/kraken.py
@@ -37,7 +37,4 @@ class Kraken(FakeCCXT):
         json_resp = resp.json()
         result = json_resp.get("result")
         price = result["XXRPZUSD"]["c"][0]
-        return {
-            "last": price
-        }
-
+        return {"last": price}

--- a/src/xrp_price_aggregate/providers/kraken.py
+++ b/src/xrp_price_aggregate/providers/kraken.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict
+
+from .base import FakeCCXT
+
+
+class Kraken(FakeCCXT):
+    """
+    Kraken has a public endpoint for fetching a price of a symbol.
+    """
+
+    fetch_ticker_url = "https://api.kraken.com/0/public/Ticker"
+
+    @property
+    def id(self) -> str:
+        return "kraken"
+
+    @classmethod
+    def price_to_precision(cls, _, value: str) -> str:
+        """We have no intelligence for precision in this client"""
+        return value
+
+    async def fetch_ticker(self, symbol: str) -> Dict[str, str]:
+        """Grab the response from our endpoint
+
+        Grab the response from our endpoint, return a dict with the expected
+        key of "last"
+
+
+        Args:
+            symbol (str): The symbol to request from the endpoint, like XRPUSD
+
+        Returns:
+            Dict of [str, str]: The results in a shape that includes our
+                                expected "last" key
+        """
+        resp = await self.client.get(self.fetch_ticker_url, params={"pair": symbol})
+        json_resp = resp.json()
+        result = json_resp.get("result")
+        price = result["XXRPZUSD"]["c"][0]
+        return {
+            "last": price
+        }
+


### PR DESCRIPTION
- added `Binance` and `Kraken` `FakeCCXT` clients using the optimized price endpoint for speed
- `ExchangeClient`s that are fast will `hasattr("fast", ExchangeClient) and ExchangeClient.fast == True` these clients use optimized endpoints or are significantly faster than their counterparts in ccxt which does collect much more market data than we're currently interested in
- adds simple option parsing to invoking the module, it will call with `fast` (optimized endpoints) by default or if provided any of the long or short options, will include all `ExchangeClients` (`ExchangeClients.fast == True` included)
- some janitorial stuff prepping for a minor rev
- all Exchange calls are now delayed in sequence of their previous call, before all calls would be gathered concurrently, with the slowest call + delay being the delay for each round of calls (provided by `count`); what this means is that no time is wasted in between each subsequent call per client - the time for all calls for the aggregate results to complete will be the slowest of all chained calls, this could result in faster overall performance when doing many rounds of aggregate calls together and streamlines the workflow into concurrent requests of each chain of tasks of `fetch() -> delay() -> ...`
