### PR TITLE
0.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 Based on [XRPL-Labs/XRP-Price-Aggregator](https://github.com/XRPL-Labs/XRP-Price-Aggregator)
 
-![PyPI](https://img.shields.io/pypi/v/xrp-price-aggregate)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/xrp-price-aggregate)
-![PyPI - Wheel](https://img.shields.io/pypi/wheel/xrp-price-aggregate)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/xrp-price-aggregate)
-![PyPI - Implementation](https://img.shields.io/pypi/implementation/xrp-price-aggregate)
-![PyPI - License](https://img.shields.io/pypi/l/xrp-price-aggregate)
-
+[![PyPI](https://img.shields.io/pypi/v/xrp-price-aggregate)][pypi]
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/xrp-price-aggregate)][pypi]
+[![PyPI - Wheel](https://img.shields.io/pypi/wheel/xrp-price-aggregate)][pypi]
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/xrp-price-aggregate)][pypi]
+[![PyPI - Implementation](https://img.shields.io/pypi/implementation/xrp-price-aggregate)][pypi]
+[![PyPI - License](https://img.shields.io/pypi/l/xrp-price-aggregate)][pypi]
 
 
 # Usage
@@ -85,3 +84,5 @@ agg_results = xrp_price_aggregate.as_dict(count=6, delay=3)
 [**Public Colab Example Notebook**](https://colab.research.google.com/drive/1OyV4P6dMFy3kBhV7FQNBW0lwHekkwAI6),
 backup of the `.ipynb` [as a Gist](https://gist.github.com/yyolk/c293b66cea913c5b6dc3939a7f38b8bd)
 
+
+[pypi]: https://pypi.org/project/xrp-price-aggregate/ "xrp-price-aggregate - PyPi"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Based on [XRPL-Labs/XRP-Price-Aggregator](https://github.com/XRPL-Labs/XRP-Price-Aggregator)
 
+![PyPI](https://img.shields.io/pypi/v/xrp-price-aggregate)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/xrp-price-aggregate)
+![PyPI - Wheel](https://img.shields.io/pypi/wheel/xrp-price-aggregate)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/xrp-price-aggregate)
+![PyPI - Implementation](https://img.shields.io/pypi/implementation/xrp-price-aggregate)
+![PyPI - License](https://img.shields.io/pypi/l/xrp-price-aggregate)
+
+
 
 # Usage
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@
 [metadata]
 license_files = LICENSE
 name = xrp-price-aggregate
-version = 0.0.9
+version = 0.0.10
 author = Joseph Chiocchi
 author_email = joe@yolk.cc
 description = A utility library that wraps grabbing the current spot price of $XRP from various exchanges.

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -96,6 +96,22 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
     return exchanges, exchange_with_tickers
 
 
+def _filter_on_client_attr(attr: str) -> Callable[[ExchangeClient], bool]:
+    return lambda exchange_client: (
+        hasattr(exchange_client, attr) and getattr(exchange_client, attr) is True
+    )
+
+
+# def _filter_gen(exchange_client_fpred, exchange_with_ticker_fpred):
+#     exchanges, exchange_with_tickers = generate_default()
+#     filtered_exchanges = set(filter(exchange_client_fpred, exchanges))
+#     filtered_exchange_with_tickers = list(
+#         filter(exchange_with_ticker_fpred, exchange_with_tickers)
+#     )
+#
+#     ...
+
+
 def generate_fast() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, str]]]:
     """
     This will return the exchanges filtered from the default set if they have
@@ -103,11 +119,7 @@ def generate_fast() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, str
     """
     exchanges, exchange_with_tickers = generate_default()
     # set up our filter predicates
-    filter_pred_fast_exchange_client: Callable[
-        [ExchangeClient], bool
-    ] = lambda exchange_client: (
-        hasattr(exchange_client, "fast") and exchange_client.fast == True
-    )
+    filter_pred_fast_exchange_client = _filter_on_client_attr("fast")
     filter_pred_fast_exchange_with_ticker: Callable[
         [Tuple[ExchangeClient, str]], bool
     ] = lambda exchange_ticker: filter_pred_fast_exchange_client(exchange_ticker[0])
@@ -116,3 +128,16 @@ def generate_fast() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, str
         filter(filter_pred_fast_exchange_with_ticker, exchange_with_tickers)
     )
     return filtered_exchanges, filtered_exchange_with_tickers
+
+
+# class ProviderFactory:
+#     """A Factory of Providers
+#
+#     To replace gen_default, while retaining a glob-like approache to all
+#     available exchanges with toggles on those clients for filtering what is
+#     added in.
+#     """
+#
+#     def __init__(self, exchange_client_fpred, exchange_with_ticker_fpred):
+#         self.exchange_client_fpred = exchange_client_fpred
+#         self.exchange_with_ticker_fpred = exchange_client_fpred

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -8,6 +8,7 @@ from .bitstamp import Bitstamp
 from .bitrue import Bitrue
 from .hitbtc import Hitbtc
 from .kraken import Kraken
+from .xrpl_oracle import XRPLOracle
 
 
 def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, str]]]:
@@ -54,6 +55,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
     binance2 = Binance()
     kraken2 = Kraken()
     hitbtc2 = Hitbtc()
+    xrpl_oracle = XRPLOracle()
     # combine them all into a set for reference and iterating later
     exchanges = {
         binance,
@@ -68,6 +70,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
         bitrue,
         binance2,
         kraken2,
+        xrpl_oracle,
     }
 
     # this could be more intelligently created, but this literal mapping is
@@ -88,6 +91,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
         (bitrue, "XRPUSDT"),
         (binance2, "XRPUSDT"),
         (kraken2, "XRPUSD"),
+        (xrpl_oracle, "USD"),
     ]
     return exchanges, exchange_with_tickers
 

--- a/src/xrp_price_aggregate/providers/xrpl_oracle.py
+++ b/src/xrp_price_aggregate/providers/xrpl_oracle.py
@@ -1,0 +1,59 @@
+"""
+This will call the XRPL oracle to grab the price
+"""
+import statistics
+from decimal import Decimal
+from typing import Dict
+
+from .base import FakeCCXT
+
+
+XRPL_ORACLE__UNICORN_CAT = "r9PfV3sQpKLWxccdg3HL2FXKxGW2orAcLE"
+
+
+class XRPLOracle(FakeCCXT):
+    """
+    Bitstamp has a public endpoint for fetching a price of a symbol.
+    """
+
+    # assume mainnet
+    fetch_ticker_url = "https://xrplcluster.com"
+
+    @property
+    def id(self) -> str:
+        return "xrpl_oracle"
+
+    @classmethod
+    def price_to_precision(cls, _: str, value: str) -> str:
+        """We have no intelligence for precision in this client"""
+        return value
+
+    async def fetch_ticker(self, symbol: str) -> Dict[str, str]:
+        """Grab the response from our endpoint
+
+        Grab the response from our endpoint, return a dict with the expected
+        key of "last"
+
+
+        Args:
+            symbol (str): The symbol to request from the endpoint, like xrpusd
+
+        Returns:
+            Dict of [str, str]: The results in a shape that includes our
+                                expected "last" key
+        """
+
+        resp = await self.client.post(
+            self.fetch_ticker_url,
+            json={
+                "method": "account_lines",
+                "params": [{"account": XRPL_ORACLE__UNICORN_CAT}],
+            },
+        )
+        json_resp = resp.json()
+        trust_lines = json_resp["result"]["lines"]
+        average = statistics.mean(
+            Decimal(trust_line["limit_peer"])
+            for trust_line in filter(lambda tl: tl["currency"] == symbol, trust_lines)
+        )
+        return {"last": str(average)}

--- a/src/xrp_price_aggregate/providers/xrpl_oracle.py
+++ b/src/xrp_price_aggregate/providers/xrpl_oracle.py
@@ -60,6 +60,9 @@ class XRPLOracle(FakeCCXT):
                 successful = True
                 json_resp = resp.json()
                 trust_lines = json_resp["result"]["lines"]
+                # take the mean of all the limit_peer amounts if that amount is
+                # in the currency we're interested in from all the trust_lines
+                # for this oracle account
                 average = statistics.mean(
                     Decimal(trust_line["limit_peer"])
                     for trust_line in filter(lambda tl: tl["currency"] == symbol, trust_lines)

--- a/src/xrp_price_aggregate/providers/xrpl_oracle.py
+++ b/src/xrp_price_aggregate/providers/xrpl_oracle.py
@@ -20,7 +20,6 @@ class XRPLOracle(FakeCCXT):
 
     # assume mainnet
     fetch_ticker_url = "https://xrplcluster.com"
-    # we might want other ways of reading this data
     xrpl_oracle = True
 
     @property
@@ -66,5 +65,7 @@ class XRPLOracle(FakeCCXT):
                     for trust_line in filter(lambda tl: tl["currency"] == symbol, trust_lines)
                 )
             else:
+                # retry every 50 ms, this can be be more intelligent with
+                # backoff and jitter
                 await asyncio.sleep(0.05)
         return {"last": str(average)}


### PR DESCRIPTION
- add XRPLOracle provider


as this library is [used in producing the data](https://github.com/yyolk/xrpl-price-persist-oracle-sam/blob/ad6e46a184506c1b170537a192ea7c7c2659a34a/oracle/requirements.txt#L1), 

<details> <summary> brain dump </summary>

this may smooth out any wrinkles or skew things! This should provide some more noise and variance to the data as we're capturing the first 30s of the minute, this will then be the spot prices for 30s after the missed 30s...

</details>

lets see how it goes :sunglasses: 