### PR TITLE
0.0.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@
 [metadata]
 license_files = LICENSE
 name = xrp-price-aggregate
-version = 0.0.10
+version = 0.0.11
 author = Joseph Chiocchi
 author_email = joe@yolk.cc
 description = A utility library that wraps grabbing the current spot price of $XRP from various exchanges.
@@ -41,6 +41,7 @@ include_package_data = True
 install_requires =
     ccxt~=1.54.45
     httpx~=0.18.2
+    websockets~=9.1
 
 
 [options.packages.find]

--- a/src/xrp_price_aggregate/providers/__init__.py
+++ b/src/xrp_price_aggregate/providers/__init__.py
@@ -1,5 +1,5 @@
 from .base import ExchangeClient
-from .gen_default import generate_default, generate_fast
+from .gen_default import generate_default, generate_fast, generate_oracle
 
 
-__all__ = ["ExchangeClient", "generate_default", "generate_fast"]
+__all__ = ["ExchangeClient", "generate_default", "generate_fast", "generate_oracle"]

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -103,36 +103,16 @@ def _filter_on_client_attr(attr: str) -> Callable[[ExchangeClient], bool]:
     )
 
 
-def _filter_gen(exchange_client_fpred, exchange_with_ticker_fpred):
+def _filter_gen(
+    exchange_client_fpred: Callable[[ExchangeClient], bool],
+    exchange_with_ticker_fpred: Callable[[Tuple[ExchangeClient, str]], bool],
+) -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, str]]]:
     exchanges, exchange_with_tickers = generate_default()
     filtered_exchanges = set(filter(exchange_client_fpred, exchanges))
     filtered_exchange_with_tickers = list(
         filter(exchange_with_ticker_fpred, exchange_with_tickers)
     )
     return filtered_exchanges, filtered_exchange_with_tickers
-
-
-# def generate_fast() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, str]]]:
-#     """
-#     This will return the exchanges filtered from the default set if they have
-#     a `fast` attribute.
-#     """
-#     # exchanges, exchange_with_tickers = generate_default()
-#     # # set up our filter predicates
-#     filter_pred_fast_exchange_client = _filter_on_client_attr("fast")
-#     filter_pred_fast_exchange_with_ticker: Callable[
-#         [Tuple[ExchangeClient, str]], bool
-#     ] = lambda exchange_ticker: filter_pred_fast_exchange_client(exchange_ticker[0])
-#     return _filter_gen(
-#         filter_pred_fast_exchange_client,
-#         filter_pred_fast_exchange_with_ticker,
-#     )
-#
-#     # filtered_exchanges = set(filter(filter_pred_fast_exchange_client, exchanges))
-#     # filtered_exchange_with_tickers = list(
-#     #     filter(filter_pred_fast_exchange_with_ticker, exchange_with_tickers)
-#     # )
-#     # return filtered_exchanges, filtered_exchange_with_tickers
 
 
 # class ProviderFactory:
@@ -148,7 +128,9 @@ def _filter_gen(exchange_client_fpred, exchange_with_ticker_fpred):
 #         self.exchange_with_ticker_fpred = exchange_client_fpred
 
 filter_pred_fast_exchange_client = _filter_on_client_attr("fast")
-filter_pred_non_oracle_client = lambda exchange_client: not (
+filter_pred_non_oracle_client: Callable[
+    [Tuple[ExchangeClient, str]], bool
+] = lambda exchange_client: not (
     hasattr(exchange_client, "xrpl_oracle")
     and getattr(exchange_client, "xrpl_oracle") is True
 )
@@ -163,7 +145,5 @@ generate_fast = partial(
 generate_oracle = partial(
     _filter_gen,
     filter_pred_non_oracle_client,
-    lambda exchange_ticker: filter_pred_non_oracle_client(
-        exchange_ticker[0]
-    ),
+    lambda exchange_ticker: filter_pred_non_oracle_client(exchange_ticker[0]),
 )

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -98,9 +98,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
 
 
 def _filter_on_client_attr(attr: str) -> Callable[[ExchangeClient], bool]:
-    return lambda exchange_client: (
-        hasattr(exchange_client, attr) and getattr(exchange_client, attr) is True
-    )
+    return lambda exchange_client: getattr(exchange_client, attr, False) is True
 
 
 def _filter_gen(
@@ -128,11 +126,8 @@ def _filter_gen(
 #         self.exchange_with_ticker_fpred = exchange_client_fpred
 
 filter_pred_fast_exchange_client = _filter_on_client_attr("fast")
-filter_pred_non_oracle_client: Callable[
-    [Tuple[ExchangeClient, str]], bool
-] = lambda exchange_client: not (
-    hasattr(exchange_client, "xrpl_oracle")
-    and getattr(exchange_client, "xrpl_oracle") is True
+filter_pred_non_oracle_client: Callable[[Tuple[ExchangeClient, str]], bool] = (
+    lambda exchange_client: not getattr(exchange_client, "xrpl_oracle", False) is True
 )
 
 

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -9,6 +9,7 @@ from .bitstamp import Bitstamp
 from .bitrue import Bitrue
 from .hitbtc import Hitbtc
 from .kraken import Kraken
+from .threexrp import ThreeXRP
 from .xrpl_oracle import XRPLOracle
 
 
@@ -56,6 +57,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
     binance2 = Binance()
     kraken2 = Kraken()
     hitbtc2 = Hitbtc()
+    threexrp = ThreeXRP()
     xrpl_oracle = XRPLOracle()
     # combine them all into a set for reference and iterating later
     exchanges = {
@@ -71,6 +73,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
         bitrue,
         binance2,
         kraken2,
+        threexrp,
         xrpl_oracle,
     }
 
@@ -92,6 +95,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
         (bitrue, "XRPUSDT"),
         (binance2, "XRPUSDT"),
         (kraken2, "XRPUSD"),
+        (threexrp, "USD"),
         (xrpl_oracle, "USD"),
     ]
     return exchanges, exchange_with_tickers

--- a/src/xrp_price_aggregate/providers/threexrp.py
+++ b/src/xrp_price_aggregate/providers/threexrp.py
@@ -27,9 +27,6 @@ class ThreeXRP(FakeCCXT):
     fast = False
     fetch_ticker_url = "wss://threexrp.dev"
 
-    # def __init__(self) -> None:
-    #     self.client = None
-
     @property
     def id(self) -> str:
         return "threexrp"

--- a/src/xrp_price_aggregate/providers/threexrp.py
+++ b/src/xrp_price_aggregate/providers/threexrp.py
@@ -1,0 +1,83 @@
+"""
+This will call the XRPL oracle to grab the price
+"""
+import asyncio
+import json
+import statistics
+from decimal import Decimal
+from typing import Dict
+
+import websockets
+
+from .base import FakeCCXT
+
+# how long to listen to incoming messages for, if we keep this short, we can
+# return a narrow window of all trades available to ThreeXRP
+# in the future, we'll want to handle this more optimally giving all providers
+# max time to do work with as many results as possible for aggregating
+# LISTEN_FOR_SECONDS = 10
+LISTEN_FOR_SECONDS = 1.337
+
+
+class ThreeXRP(FakeCCXT):
+    """
+    Look up data that was persisted to the XRPL via the XRPL Oracles.
+    """
+
+    fast = False
+    fetch_ticker_url = "wss://threexrp.dev"
+
+    # def __init__(self) -> None:
+    #     self.client = None
+
+    @property
+    def id(self) -> str:
+        return "threexrp"
+
+    @classmethod
+    def price_to_precision(cls, _: str, value: str) -> str:
+        """We have no intelligence for precision in this client"""
+        return value
+
+    async def fetch_ticker(self, symbol: str) -> Dict[str, str]:
+        """Grab the response from our endpoint
+
+        Grab the response from our endpoint, return a dict with the expected
+        key of "last"
+
+
+        Args:
+            symbol (str): The symbol to request from the endpoint, like xrpusd
+
+        Returns:
+            Dict of [str, str]: The results in a shape that includes our
+                                expected "last" key
+        """
+        async with websockets.connect(self.fetch_ticker_url) as websocket:  # type: ignore
+            await websocket.send(
+                json.dumps(
+                    {
+                        "request": "SUBSCRIBE",
+                        "message": "threexrp v2 signin",
+                        "channel": "trade",
+                    }
+                )
+            )
+            loop = asyncio.get_event_loop()
+            start = loop.time()
+            prices = []
+            async for message in websocket:
+                parsed_message = json.loads(message)
+                trade = parsed_message.get("trade")
+                if trade["f"] == symbol:
+                    prices.append(Decimal(trade["p"]))
+                    # we at least got one trade of the symbol we're looking for
+                    if loop.time() - start > LISTEN_FOR_SECONDS:
+                        break
+            final_price = statistics.mean(prices)
+
+        return {"last": str(final_price)}
+
+    async def close(self) -> None:
+        """We close exiting context_manager of our fetch_ticker client"""
+        pass

--- a/src/xrp_price_aggregate/providers/xrpl_oracle.py
+++ b/src/xrp_price_aggregate/providers/xrpl_oracle.py
@@ -68,7 +68,9 @@ class XRPLOracle(FakeCCXT):
                 # for this oracle account
                 average = statistics.mean(
                     Decimal(trust_line["limit_peer"])
-                    for trust_line in filter(lambda tl: tl["currency"] == symbol, trust_lines)
+                    for trust_line in filter(
+                        lambda tl: tl["currency"] == symbol, trust_lines
+                    )
                 )
             else:
                 # retry every 50 ms, this can be be more intelligent with

--- a/src/xrp_price_aggregate/providers/xrpl_oracle.py
+++ b/src/xrp_price_aggregate/providers/xrpl_oracle.py
@@ -18,6 +18,9 @@ class XRPLOracle(FakeCCXT):
     Look up data that was persisted to the XRPL via the XRPL Oracles.
     """
 
+    # although the retrieval is generally considered 'fast', the frequency of
+    # updates isn't (1/min)
+    fast = False
     # assume mainnet
     fetch_ticker_url = "https://xrplcluster.com"
     xrpl_oracle = True


### PR DESCRIPTION
- exclude the oracle in another parameter (now getting unwieldy)
- move special functionality to `partial(...)`
- boilerplate `ProviderConfigFactory` class for minor release
- add [threexrp.dev](https://threexrp.dev) provider