### PR TITLE
0.0.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@
 [metadata]
 license_files = LICENSE
 name = xrp-price-aggregate
-version = 0.0.12
+version = 0.0.13
 author = Joseph Chiocchi
 author_email = joe@yolk.cc
 description = A utility library that wraps grabbing the current spot price of $XRP from various exchanges.

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -1,3 +1,7 @@
+"""
+TODO:
+    - https://github.com/yyolk/xrp-price-aggregate/issues/13
+"""
 from functools import partial
 from typing import Callable, List, Set, Tuple
 
@@ -9,7 +13,7 @@ from .bitstamp import Bitstamp
 from .bitrue import Bitrue
 from .hitbtc import Hitbtc
 from .kraken import Kraken
-from .threexrp import ThreeXRP
+# from .threexrp import ThreeXRP
 from .xrpl_oracle import XRPLOracle
 
 
@@ -57,7 +61,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
     binance2 = Binance()
     kraken2 = Kraken()
     hitbtc2 = Hitbtc()
-    threexrp = ThreeXRP()
+    # threexrp = ThreeXRP()
     xrpl_oracle = XRPLOracle()
     # combine them all into a set for reference and iterating later
     exchanges = {
@@ -73,7 +77,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
         bitrue,
         binance2,
         kraken2,
-        threexrp,
+        # threexrp,
         xrpl_oracle,
     }
 
@@ -95,7 +99,7 @@ def generate_default() -> Tuple[Set[ExchangeClient], List[Tuple[ExchangeClient, 
         (bitrue, "XRPUSDT"),
         (binance2, "XRPUSDT"),
         (kraken2, "XRPUSD"),
-        (threexrp, "USD"),
+        # (threexrp, "USD"),
         (xrpl_oracle, "USD"),
     ]
     return exchanges, exchange_with_tickers

--- a/src/xrp_price_aggregate/providers/threexrp.py
+++ b/src/xrp_price_aggregate/providers/threexrp.py
@@ -35,6 +35,8 @@ class ThreeXRP(FakeCCXT):
 
     fast = False
     fetch_ticker_url = "wss://threexrp.dev"
+    # pretend we're the oracle so we're skipped in filtering?
+    # xrpl_oracle = True
 
     @property
     def id(self) -> str:


### PR DESCRIPTION
exclude threexrp.dev temporarily closes #14 


```sh
(xrp-price-aggregate) [yolk@gilt src]$ time python -c 'import xrp_price_aggregate ; print(xrp_price_aggregate.as_dict(2, 1, False, False)["raw_results_named"].keys())'
dict_keys(['hitbtc', 'bitstamp', 'xrpl_oracle', 'binance', 'ftx', 'kraken', 'cex', 'bitfinex', 'bitrue'])

real    0m11.858s
user    0m1.685s
sys     0m0.125s
(xrp-price-aggregate) [yolk@gilt src]$ time python -c 'import xrp_price_aggregate ; print(xrp_price_aggregate.as_dict(2, 1, False, True)["raw_results_named"].keys())'
dict_keys(['cex', 'kraken', 'bitstamp', 'bitfinex', 'binance', 'bitrue', 'hitbtc', 'ftx'])

real    0m11.819s
user    0m1.891s
sys     0m0.181s
(xrp-price-aggregate) [yolk@gilt src]$ time python -c 'import xrp_price_aggregate ; print(xrp_price_aggregate.as_dict(2, 1, True, True)["raw_results_named"].keys())'
dict_keys(['bitstamp', 'hitbtc', 'xrpl_oracle', 'binance', 'ftx', 'kraken', 'cex', 'bitfinex', 'bitrue'])

real    0m11.795s
user    0m1.860s
sys     0m0.175s
(xrp-price-aggregate) [yolk@gilt src]$ time python -c 'import xrp_price_aggregate ; print(xrp_price_aggregate.as_dict(2, 1, True, False)["raw_results_named"].keys())'
dict_keys(['hitbtc', 'bitstamp', 'kraken', 'binance', 'bitrue'])

real    0m3.525s
user    0m0.527s
sys     0m0.082s
```

