### PR TITLE
0.0.14

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@
 [metadata]
 license_files = LICENSE
 name = xrp-price-aggregate
-version = 0.0.13
+version = 0.0.14
 author = Joseph Chiocchi
 author_email = joe@yolk.cc
 description = A utility library that wraps grabbing the current spot price of $XRP from various exchanges.

--- a/src/xrp_price_aggregate/providers/gen_default.py
+++ b/src/xrp_price_aggregate/providers/gen_default.py
@@ -13,6 +13,7 @@ from .bitstamp import Bitstamp
 from .bitrue import Bitrue
 from .hitbtc import Hitbtc
 from .kraken import Kraken
+
 # from .threexrp import ThreeXRP
 from .xrpl_oracle import XRPLOracle
 


### PR DESCRIPTION
Return our exceptions instead of fail-fast. We'll filter them out during the aggregate step. Each failure also will not continue that provider's results chain.

refs yyolk/xrpl-price-persist-oracle#27
